### PR TITLE
sc-192 - Fix component name in the stories index template file

### DIFF
--- a/scripts/components/templates/stories/index.hbs
+++ b/scripts/components/templates/stories/index.hbs
@@ -7,13 +7,13 @@ import { theme } from './{{{optionCap}}}-theme.stories'
 
 export const {{{optionCap}}} = (args) => <{{{cap}}} {...args}>Hello World</{{{cap}}}>
 
-Default.args = {
+{{{optionCap}}}.args = {
     appearance: 'primary',
     size: 'large',
     theme: 'default'
 }
 
-Default.argTypes = {
+{{{optionCap}}}.argTypes = {
     appearance,
     size,
     theme


### PR DESCRIPTION
https://app.shortcut.com/osgca/story/192/fix-component-name-in-the-stories-index-template-file

The current template file has a default value set to "Default", this way, after creating a new component option, the new option won't be displayed on Storybook.
```
/Users/cicerofonseca/Projects/owl-ui/scripts/components/templates/stories/index.hbs
```