### PR TITLE
[sc-201] - Update editor and prettier settings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "arrowParens": "avoid",
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "tabWidth": 2
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,13 +1,23 @@
 {
-    "xd.lastPackage": "/Users/chrisaube/Documents/GitHub/owl-ui/design/owl-ui",
-    "xd.globalEditor": true,
-    "cSpell.words": [
-        "npmignore",
-        "owlui",
-        "postcssrc",
-        "Scrowl",
-        "strs",
-        "templater",
-        "utls"
-    ]
+  "eslint.format.enable": true,
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true,
+    "source.fixAll.stylelint": true,
+    "source.fixAll.tslint": true
+  },
+  "editor.tabSize": 2,
+  "editor.insertSpaces": true,
+  "editor.detectIndentation": false,
+  "xd.lastPackage": "/Users/chrisaube/Documents/GitHub/owl-ui/design/owl-ui",
+  "xd.globalEditor": true,
+  "cSpell.words": [
+    "npmignore",
+    "owlui",
+    "postcssrc",
+    "Scrowl",
+    "strs",
+    "templater",
+    "utls"
+  ]
 }


### PR DESCRIPTION
[Shortcut story](https://app.shortcut.com/osgca/story/201/update-tabwidth-prettier-configuration)

This will format the project code on save using two spaces instead of four, this way we'll be consistent among projects and also able to fit more code horizontally on the screen.