### PR TITLE
[sc-335] - Type information location is wrong

### DIFF
--- a/packages/button/tsconfig.json
+++ b/packages/button/tsconfig.json
@@ -1,18 +1,12 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "types": [
-            "custom-globals",
-            "static-assets",
-        ],
-        "typeRoots": [
-            "../../node_modules/@types",
-            "../../typings"
-        ]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "../src/*": ["./*"]
     },
-    "exclude": [
-        "dist/*",
-        "**/*.stories.ts",
-        "**/*.stories.tsx"
-    ]
+    "types": ["custom-globals", "static-assets"],
+    "typeRoots": ["../../node_modules/@types", "../../typings"]
+  },
+  "exclude": ["dist/*", "**/*.stories.ts", "**/*.stories.tsx"]
 }

--- a/packages/textfield/tsconfig.json
+++ b/packages/textfield/tsconfig.json
@@ -1,18 +1,12 @@
 {
-    "extends": "../../tsconfig.base.json",
-    "compilerOptions": {
-        "types": [
-            "custom-globals",
-            "static-assets",
-        ],
-        "typeRoots": [
-            "../../node_modules/@types",
-            "../../typings"
-        ]
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "../src/*": ["./*"]
     },
-    "exclude": [
-        "dist/*",
-        "**/*.stories.ts",
-        "**/*.stories.tsx"
-    ]
+    "types": ["custom-globals", "static-assets"],
+    "typeRoots": ["../../node_modules/@types", "../../typings"]
+  },
+  "exclude": ["dist/*", "**/*.stories.ts", "**/*.stories.tsx"]
 }

--- a/scripts/components/templates/package/tsconfig.hbs
+++ b/scripts/components/templates/package/tsconfig.hbs
@@ -1,6 +1,10 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
+        "baseUrl": ".",
+        "paths": {
+          "../src/*": ["./*"]
+        },
         "types": [
             "custom-globals",
             "static-assets",


### PR DESCRIPTION
### Short summary
When parcel builds the dist folder, the import links to the types is not correct:

`props: Partial<import("Default/Default.types")`

it should be:

`props: Partial<import("../src/Default/Default.types")`

---

### Test steps
1 - Run `yarn build:dist`
2- Check out the `packages/button/dist/types.d.ts` file. The imports path should contain `../src/` before the option folder and types file.
3 - Create a brand new component using `yarn create:component button@newButton`.
4 - Repeat steps 1 and 2.