### PR TITLE
[sc-381] - Remove unnecessary SCSS modules

### DIFF
--- a/packages/table/src/_index.scss
+++ b/packages/table/src/_index.scss
@@ -1,2 +1,2 @@
 @forward './Default/styles.module.scss' as defaultTable-*;
-@forward './Default/elements/styles.module.scss' as tableElement-*;
+@forward './Default/elements/styles.module.scss' as tableElements-*;


### PR DESCRIPTION
### Short summary
Remove unnecessary SCSS module declarations that were breaking the project building.

---

### Test steps

1. Run `yarn build:dist` and ensure the building process will be completed with no errors.
