### PR TITLE
[sc-614] - Update Icon Props

### DIFF
--- a/packages/icons/src/Default/Default.tsx
+++ b/packages/icons/src/Default/Default.tsx
@@ -5,7 +5,7 @@ import * as styleMod from './styles.module.scss';
 const baseClass = 'icons';
 
 export const Component = (props: IconsDefaultProps) => {
-  const { className, style, ariaHidden } = props;
+  const { className, style, 'aria-hidden': ariaHidden } = props;
 
   const modulePrefix = props.prefix;
   const icon = props.icon;

--- a/packages/icons/src/Default/Default.types.ts
+++ b/packages/icons/src/Default/Default.types.ts
@@ -938,7 +938,6 @@ export type Icon =
   | 'zoom_out_map';
 
 export interface IconsDefaultCommons {
-  ariaHidden?: boolean;
   display?: 'Filled' | 'Outlined';
   appearance?: 'Primary' | 'Alt';
   theme?: 'Default' | 'Dark' | 'Light';


### PR DESCRIPTION
### Short summary
- Added `role="img"` to make screen readers aware of the span element.
- Added a new `ariaHidden` boolean prop that will be used to set the `aria-hidden` for decorative icons

*Initially, I thought that spreading props would accept new props, but it also adds props we don't want to the element, such as appearance and size.

---

### Test steps
1. Use the new `ariaHidden` prop and ensure the `aria-hidden` property will be added to the rendered `<span>` element.
