### PR TITLE
Fix box-shadow warnings, and lint warnings

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -39,7 +39,7 @@ To use the design we need to import the design file from XD then create a Design
 
 The DSP makes use of reference and contextual tokens. Reference tokens are hard values taken from import of the XD file. The contextual tokens are custom to the DSP and use the reference tokens as a value. This methodology has been directly inspired from [material design](https://m3.material.io/foundations/design-tokens/overview).
 
-#### Example
+### Example
 
 > `owl.ref.palette.dark` is used as the value for `owl.sys.color.on.light` and `owl.sys.bg.dark`.
 

--- a/lib/src/theme/dark/_index.scss
+++ b/lib/src/theme/dark/_index.scss
@@ -16,6 +16,7 @@
 
   --owl-close-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='white'><path d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/></svg>");
 
+  --owl-input-color: var(--bs-body-color);
   --owl-input-bg: var(--bs-gray-700);
   --owl-input-placeholder-color: var(--bs-gray-400);
   --owl-input-border-color: var(--bs-black);
@@ -74,6 +75,7 @@
   --owl-sidebar-header-bg: var(--bs-gray-800);
   --owl-sidebar-header-color: var(--bs-gray-500);
 
+  // Chatbox
   --owl-chatbox-bg: var(--bs-gray-700);
   --owl-chatbox-bg-hover: var(--bs-gray-600);
 

--- a/lib/src/theme/default/_index.scss
+++ b/lib/src/theme/default/_index.scss
@@ -32,7 +32,6 @@
   --owl-accordion-btn-active-bg: var(--bs-gray-200);
 
   --owl-border-color: var(--bs-gray-500);
-  --owl-border-width: var(--bs-border-width);
 
   --owl-dropdown-color: var(--bs-gray-800);
   --owl-dropdown-bg: var(--bs-white);

--- a/lib/src/theme/default/_index.scss
+++ b/lib/src/theme/default/_index.scss
@@ -1,10 +1,6 @@
 @use '../global/variables' as *;
 @use '../global/tokens' as *;
 
-:root {
-
-}
-
 :root,
 .theme--default {
   --bs-body-bg: var(--bs-gray-100);

--- a/lib/src/theme/global/_bootstrap.scss
+++ b/lib/src/theme/global/_bootstrap.scss
@@ -115,7 +115,7 @@ $btn-padding-x-lg: 1.25em;
 $btn-border-width: 1px;
 $btn-line-height: 1.5;
 $btn-font-weight: 600;
-$btn-box-shadow: none;
+$btn-box-shadow: null;
 
 $btn-border-radius: 0.25em;
 $btn-border-radius-sm: 0.25em;
@@ -134,7 +134,7 @@ $input-disabled-bg: var(--owl-input-border-color);
 $input-transition: $btn-transition;
 $input-bg: var(--owl-input-bg);
 $input-color: var(--owl-input-color);
-$input-box-shadow: none;
+$input-box-shadow: null;
 $input-border-color: var(--owl-input-border-color);
 $input-focus-border-color: var(--owl-active-bg);
 $input-placeholder-color: var(--owl-input-placeholder-color);

--- a/lib/src/theme/global/_bootstrap.scss
+++ b/lib/src/theme/global/_bootstrap.scss
@@ -516,4 +516,6 @@ $all-colors: map-merge-multiple(
   --owl-typeface-label-weight: 700;
   --owl-typeface-label-letterspacing: 0.025em;
   --owl-typeface-label-texttransform: uppercase;
+
+  --owl-border-width: var(--bs-border-width);
 }

--- a/packages/card/src/Default/styles.module.scss
+++ b/packages/card/src/Default/styles.module.scss
@@ -3,20 +3,6 @@
 .card {
   $ref: &;
 
-  &.theme--dark {
-    &.bg-light {
-      // Example of how to implement theming to bootstrap variant
-      // you can use css vars or scss vars
-      // --bs-card-color: var(--bs-white);
-      // --bs-btn-active-color: #{utils.$owl-ref-palette-white};
-      // --bs-btn-active-bg: var(--bs-gray-800);
-      // --bs-btn-active-border-color: var(--bs-gray-800);
-      // --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125);
-      // --bs-btn-disabled-bg: var(--bs-gray-500);
-      // --bs-btn-disabled-border-color: var(--bs-gray-500);
-    }
-  }
-
   &#{$ref}--size {
     &-lg {
       @include utils.typeface-lg;

--- a/packages/closeButton/src/Default/styles.module.scss
+++ b/packages/closeButton/src/Default/styles.module.scss
@@ -4,17 +4,6 @@
   $ref: &;
   @include utils.typeface-sm;
 
-  &-primary {
-    &.theme--dark {
-      // Example of how to implement theming to bootstrap variant
-      // you can use css vars or scss vars. Inspect the element on
-      // Storybook to check out the variables to be updated
-      // --bs-btn-color: var(--bs-white);
-      // --bs-btn-bg: var(--bs-gray-500);
-      // --bs-btn-border-color: #{utils.$owl-ref-palette-gray-500};
-    }
-  }
-
   &#{$ref}--size {
     &-lg {
       @include utils.typeface-lg;


### PR DESCRIPTION
### Short summary

- Change `none` to `null` for bootstrap box shadow variables
- Remove some empty styles
- warning in readme about heading level increasing by more than 1.

---

### Test steps

1. There should be no change to the application
2. Terminal messages have warnings removed.
